### PR TITLE
add contiuous integration using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+#
+# Maël Valais <mael.valais@gmail.com>
+#
+# The travis-ci servers are going to run this script on any push
+# to the repo. Basically, it
+# - tells the author of a commit if his commit has broken the build,
+# - deploys two .zip containing the linux and osx apps, with the
+#   touist compiled in it
+#
+# vim:set et sw=2 ts=2:
+
+addons:
+  apt:
+    sources:
+    - avsm
+    packages:
+    - opam
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.opam
+
+before_install:
+  - opam init --auto-setup
+  - eval `opam config env`
+install:
+  - make
+
+# The commiter will be informed that one of his commits
+# broke the build. I didn't want us to receive an email
+# each time we did a new branch, so I changed to 
+#     on_success: never
+notifications:
+  email:
+    on_success: never # default: change
+    on_failure: always # default: always


### PR DESCRIPTION
I propose to add `travis` as the CI server. It is really useful to make sure that each commit is building correctly. 😃 